### PR TITLE
Fix bug in getting classes in DomUtil.genCssSelector

### DIFF
--- a/src/scribe-analytics.js
+++ b/src/scribe-analytics.js
@@ -561,7 +561,7 @@ if (typeof Scribe === 'undefined') {
 
       while (node != document.body) {
         var id = node.id;
-        var classes = node.className.split(" ").join(".");
+        var classes = node.className.trim().split(/\s+/).join(".");
         var tagName = node.nodeName.toLowerCase();
 
         if (id && id !== "") id = '#' + id;


### PR DESCRIPTION
class attribute like "  aaa  bbb  ccc  " will result in selector like "..aaa..bbb..ccc..", while it should be "aaa.bbb.ccc"
