### PR TITLE
Fix bug in getting classes in DomUtils.genCssSelector when clicking SVG elements

### DIFF
--- a/src/scribe-analytics.js
+++ b/src/scribe-analytics.js
@@ -561,7 +561,8 @@ if (typeof Scribe === 'undefined') {
 
       while (node != document.body) {
         var id = node.id;
-        var classes = node.className.trim().split(/\s+/).join(".");
+        var classes = typeof node.className === 'string' ?
+          node.className.trim().split(/\s+/).join(".") : '';
         var tagName = node.nodeName.toLowerCase();
 
         if (id && id !== "") id = '#' + id;


### PR DESCRIPTION
clicking a SVG element like <circle> will result in an error because node.className will return a SVGAnimatedString instance rather than a string
